### PR TITLE
Add status node, remove recovery service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # HAB2_ROS2
-ROS2 Implementation for HAB
+
+This repository contains a skeleton ROS 2 layout for a high altitude balloon
+(HAB) project.  It is inspired by the original `HAB-GoatSee` code base and
+breaks each sensor interface into its own node.  The current implementation is
+lightweight and intended as a starting point for future development.
+
+## Repository Structure
+
+```
+README.md               - Project overview and ROS 2 design
+src/
+  hab_main_node.py      - Central node subscribing to all sensor topics
+  bmp280_node.py        - Publishes data from a BMP280 pressure/temperature sensor
+  bosch_pressure_node.py- Publishes data from a Bosch pressure sensor
+  mcp9600_node.py       - Publishes data from an MCP9600 thermocouple sensor
+  gps_node.py           - Publishes GPS fixes
+  status_node.py        - Aggregates data from other sensors
+  clear_i2c.py          - Utility script that clears the I2C bus
+launch/
+  hab_launch.py         - Example launch file that starts all nodes
+```
+
+## ROS 2 Implementation Outline
+
+1. **Sensor Nodes** – Each sensor (BMP280, Bosch pressure, MCP9600, GPS) runs in
+   its own node and publishes a simple `std_msgs/String` message.  Real
+   implementations would use custom message types containing the sensor data.
+2. **`hab_main_node`** – Subscribes to all sensor topics and acts as the main
+   orchestrator.  This node would be responsible for logging data, performing
+   any higher-level decision making, or relaying data via radio.
+3. **`status_node`** – Collects readings from the BMP280, Bosch pressure, and
+   MCP9600 nodes and periodically reports a summary.
+4. **I2C Recovery** – Sensor nodes directly call the helper function
+   `clear_i2c.clear_bus()` if they encounter an I²C error.
+5. **Launch File** – `launch/hab_launch.py` demonstrates how to start all nodes
+   from one launch description.  It calls `clear_i2c.py` once at startup and
+   then launches every node.
+
+This repository currently provides stub implementations only.  Sensor drivers
+from the original `HAB-GoatSee` project would need to be integrated where the
+placeholder comments appear.

--- a/launch/hab_launch.py
+++ b/launch/hab_launch.py
@@ -1,0 +1,15 @@
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        ExecuteProcess(cmd=['python3', 'src/clear_i2c.py']),
+        Node(package='hab2_ros2', executable='bmp280_node', name='bmp280'),
+        Node(package='hab2_ros2', executable='bosch_pressure_node', name='bosch_pressure'),
+        Node(package='hab2_ros2', executable='mcp9600_node', name='mcp9600'),
+        Node(package='hab2_ros2', executable='gps_node', name='gps'),
+        Node(package='hab2_ros2', executable='status_node', name='status'),
+        Node(package='hab2_ros2', executable='hab_main_node', name='hab_main'),
+    ])

--- a/src/bmp280_node.py
+++ b/src/bmp280_node.py
@@ -1,0 +1,32 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+from clear_i2c import clear_bus
+
+class BMP280Node(Node):
+    """Publishes temperature and pressure from a BMP280 sensor."""
+    def __init__(self):
+        super().__init__('bmp280_node')
+        self.publisher = self.create_publisher(String, 'bmp280/data', 10)
+        self.timer = self.create_timer(1.0, self.publish_reading)
+
+    def publish_reading(self):
+        try:
+            msg = String()
+            msg.data = 'bmp280 sample'
+            self.publisher.publish(msg)
+        except Exception as e:
+            self.get_logger().error(f'Sensor error: {e}, attempting I2C recover')
+            clear_bus()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = BMP280Node()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/bosch_pressure_node.py
+++ b/src/bosch_pressure_node.py
@@ -1,0 +1,32 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+from clear_i2c import clear_bus
+
+class BoschPressureNode(Node):
+    """Publishes pressure data from a Bosch sensor."""
+    def __init__(self):
+        super().__init__('bosch_pressure_node')
+        self.publisher = self.create_publisher(String, 'bosch_pressure/data', 10)
+        self.timer = self.create_timer(1.0, self.publish_reading)
+
+    def publish_reading(self):
+        try:
+            msg = String()
+            msg.data = 'bosch pressure sample'
+            self.publisher.publish(msg)
+        except Exception as e:
+            self.get_logger().error(f'Sensor error: {e}, attempting I2C recover')
+            clear_bus()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = BoschPressureNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/clear_i2c.py
+++ b/src/clear_i2c.py
@@ -1,0 +1,14 @@
+"""Placeholder script to clear the I2C bus if it becomes unresponsive."""
+
+import time
+import sys
+
+# Real implementation would toggle GPIO lines or use i2cset commands
+
+def clear_bus():
+    print("Clearing I2C bus...")
+    time.sleep(1)
+    print("I2C bus cleared")
+
+if __name__ == '__main__':
+    clear_bus()

--- a/src/gps_node.py
+++ b/src/gps_node.py
@@ -1,0 +1,27 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+class GPSNode(Node):
+    """Publishes GPS data."""
+    def __init__(self):
+        super().__init__('gps_node')
+        self.publisher = self.create_publisher(String, 'gps/data', 10)
+        self.timer = self.create_timer(1.0, self.publish_reading)
+
+    def publish_reading(self):
+        msg = String()
+        msg.data = 'gps sample'
+        self.publisher.publish(msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = GPSNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/hab_main_node.py
+++ b/src/hab_main_node.py
@@ -1,0 +1,29 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+class HABMainNode(Node):
+    """Central orchestrator node for HAB sensors."""
+    def __init__(self):
+        super().__init__('hab_main_node')
+        # Subscribe to topics from sensor nodes
+        self.create_subscription(String, 'bmp280/data', self.sensor_callback, 10)
+        self.create_subscription(String, 'bosch_pressure/data', self.sensor_callback, 10)
+        self.create_subscription(String, 'mcp9600/data', self.sensor_callback, 10)
+        self.create_subscription(String, 'gps/data', self.sensor_callback, 10)
+
+    def sensor_callback(self, msg):
+        # Placeholder for processing sensor data
+        self.get_logger().info(f'Received: {msg.data}')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = HABMainNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/mcp9600_node.py
+++ b/src/mcp9600_node.py
@@ -1,0 +1,32 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+from clear_i2c import clear_bus
+
+class MCP9600Node(Node):
+    """Publishes thermocouple data from the MCP9600 sensor."""
+    def __init__(self):
+        super().__init__('mcp9600_node')
+        self.publisher = self.create_publisher(String, 'mcp9600/data', 10)
+        self.timer = self.create_timer(1.0, self.publish_reading)
+
+    def publish_reading(self):
+        try:
+            msg = String()
+            msg.data = 'mcp9600 sample'
+            self.publisher.publish(msg)
+        except Exception as e:
+            self.get_logger().error(f'Sensor error: {e}, attempting I2C recover')
+            clear_bus()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = MCP9600Node()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/status_node.py
+++ b/src/status_node.py
@@ -1,0 +1,37 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+class StatusNode(Node):
+    """Aggregates readings from multiple sensors."""
+    def __init__(self):
+        super().__init__('status_node')
+        self.data = {}
+        self.create_subscription(String, 'bmp280/data', self.update_bmp280, 10)
+        self.create_subscription(String, 'bosch_pressure/data', self.update_bosch, 10)
+        self.create_subscription(String, 'mcp9600/data', self.update_mcp9600, 10)
+        self.timer = self.create_timer(5.0, self.report_status)
+
+    def update_bmp280(self, msg):
+        self.data['bmp280'] = msg.data
+
+    def update_bosch(self, msg):
+        self.data['bosch_pressure'] = msg.data
+
+    def update_mcp9600(self, msg):
+        self.data['mcp9600'] = msg.data
+
+    def report_status(self):
+        self.get_logger().info(f"Status: {self.data}")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = StatusNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- update repo overview with new status node
- remove i2c_recovery_service and call `clear_bus` directly
- add status node that aggregates sensor readings
- invoke status node from launch file

## Testing
- `python3 -c "import rclpy, sys; print('rclpy installed', rclpy.__version__)"` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684f727f5c3c8323948d7cd79d7dc2d9